### PR TITLE
Set order of club events to desc

### DIFF
--- a/bot/internal/adapters/controller/telegram/handlers/clubOwner/clubOwner.go
+++ b/bot/internal/adapters/controller/telegram/handlers/clubOwner/clubOwner.go
@@ -1469,7 +1469,7 @@ func (h Handler) eventsList(c tele.Context) error {
 		context.Background(),
 		eventsOnPage,
 		p*eventsOnPage,
-		"start_time ASC",
+		"start_time DESC",
 		clubID,
 	)
 	if err != nil {

--- a/bot/internal/adapters/database/postgres/event.go
+++ b/bot/internal/adapters/database/postgres/event.go
@@ -54,7 +54,6 @@ func (s *EventStorage) GetAll(ctx context.Context) ([]entity.Event, error) {
 
 // GetByClubID is a function that gets events by club_id with pagination from the database.
 //
-// It returns events in the order of start_time (upcoming first, then past).
 // If there are more events than limit, it returns only first limit events.
 // If there are fewer events than limit, it returns all events.
 // If there are no events, it returns empty list.


### PR DESCRIPTION
Изменение порядка сортировки мероприятий клуба на DESC, поскольку во первых более интуитивно понятно, что чем мероприятие выше, тем недавнее оно было, а во вторых в таком случае на 1 странице будут самые давние мероприятия, а чтобы посмотреть на недавно законченное мероприятие придётся перейти на условно 5 страницу, что является далеко на самым лучшим UX.
Также убран лишний комментарий в описании EventStorage.GetByClubID, поскольку он не соответствует действительности и в данной функции нет заранее объявленного порядка и он проставляется из вне.